### PR TITLE
Fix mDNS hostname and enable ArduinoOTA

### DIFF
--- a/Firmware/.gitignore
+++ b/Firmware/.gitignore
@@ -1,0 +1,5 @@
+.pio
+.vscode/.browse.c_cpp.db*
+.vscode/c_cpp_properties.json
+.vscode/launch.json
+.vscode/ipch

--- a/Firmware/README.md
+++ b/Firmware/README.md
@@ -29,18 +29,17 @@ pio run --target upload
 
 The web assets (from `data_pre` folder) are automatically minified and embedded into the firmware during the build process.
 
-### 4. OTA Updates (Web-based)
-Once the device is connected to WiFi, you can update the firmware via web browser or command line:
+### 4. OTA Updates
+Once the device is connected to WiFi, you can update the firmware over-the-air using PlatformIO:
 
-**Browser:**
-1. Build the firmware: `pio run`
-2. Open `http://winfidel.local/update` in your browser
-3. Select the firmware file: `.pio/build/esp32c3/firmware.bin`
-4. Click "Update" and wait for the upload to complete
-
-**Command line:**
 ```bash
-pio run && curl -F "firmware=@.pio/build/esp32c3/firmware.bin" http://winfidel.local/update
+pio run --target upload --environment esp32_ota
+```
+
+Or using espota.py directly:
+```bash
+pio run && ~/.platformio/packages/framework-arduinoespressif32/tools/espota.py \
+  -i winfidel.local -p 3232 -f .pio/build/esp32c3/firmware.bin
 ```
 
 The device will automatically reboot with the new firmware.

--- a/Firmware/README.md
+++ b/Firmware/README.md
@@ -12,15 +12,38 @@ Installing PlatformIO CLI is pretty straight-forward and also well documented fo
 You will need to follow few steps and get PlatformIO CLI installed, detailed tutorial can be found at https://platformio.org/install/cli
 Make sure to install [PlatformIO Core](https://docs.platformio.org/en/latest//core/installation.html#installation-methods 'https://docs.platformio.org/en/latest//core/installation.html#installation-methods') and allso that it is available trough [shell](https://docs.platformio.org/en/latest//core/installation.html#piocore-install-shell-commands 'PlatformIO Core - Install Shell Commands¶').
 
-### 2. Build firmware
-Open shell/command-prompt and navigate to 'Firmware/platformio' folder.
+### 2. Install Python dependencies
+The build process uses Python scripts to minify web assets. Install the required packages into PlatformIO's virtual environment:
 
-1. Compile and upload the firmware with `pio run --target upload --upload-port <COM-PORT>`. Make sure to replace `<COM-PORT>` with your ESP32's COM port (ie COM1 or /dev/ttyACM0)
-2. Upload the file system (Web page) with `pio run --target uploadfs --upload-port <COM-PORT>`, again replace `<COM-PORT>` with your ESP32's COM port.
-3. Restart/power-cycle your board
+```bash
+~/.platformio/penv/bin/pip install minify_html rjsmin
+```
 
-Every time you make a firmware change, you need to run step #1.
-Every time you make a change to the web page (anything inside `data` folder) you only need to run step #2.
+### 3. Build firmware
+Open shell/command-prompt and navigate to the `Firmware` folder.
+
+Compile and upload the firmware with:
+```bash
+pio run --target upload
+```
+
+The web assets (from `data_pre` folder) are automatically minified and embedded into the firmware during the build process.
+
+### 4. OTA Updates (Web-based)
+Once the device is connected to WiFi, you can update the firmware via web browser or command line:
+
+**Browser:**
+1. Build the firmware: `pio run`
+2. Open `http://winfidel.local/update` in your browser
+3. Select the firmware file: `.pio/build/esp32c3/firmware.bin`
+4. Click "Update" and wait for the upload to complete
+
+**Command line:**
+```bash
+pio run && curl -F "firmware=@.pio/build/esp32c3/firmware.bin" http://winfidel.local/update
+```
+
+The device will automatically reboot with the new firmware.
 
 
 [<- Go back to repository root](../README.md)

--- a/Firmware/README.md
+++ b/Firmware/README.md
@@ -30,7 +30,11 @@ pio run --target upload
 The web assets (from `data_pre` folder) are automatically minified and embedded into the firmware during the build process.
 
 ### 4. OTA Updates
-Once the device is connected to WiFi, you can update the firmware over-the-air using PlatformIO:
+Once the device is connected to WiFi, you can update the firmware over-the-air using ArduinoOTA.
+
+> **Note:** OTA requires the `min_spiffs.csv` partition table (configured in `platformio.ini`) which provides two app partitions for safe firmware switching.
+
+Using PlatformIO:
 
 ```bash
 pio run --target upload --environment esp32_ota

--- a/Firmware/platformio.ini
+++ b/Firmware/platformio.ini
@@ -19,7 +19,7 @@ upload_protocol = espota
 board_build.f_cpu = 160000000L
 board_build.f_flash = 80000000L
 board_build.flash_mode = qio
-board_build.partitions = huge_app.csv
+board_build.partitions = min_spiffs.csv
 
 framework = arduino
 platform = https://github.com/platformio/platform-espressif32.git

--- a/Firmware/src/main.ino
+++ b/Firmware/src/main.ino
@@ -2,7 +2,6 @@
 #include <EEPROM.h>
 #include <WiFiManager.h>
 #include <ArduinoOTA.h>
-#include <Update.h>
 #include "WiFi.h"
 #include "ESPAsyncWebServer.h"
 #include "include/PersistSettings.h"

--- a/Firmware/src/main.ino
+++ b/Firmware/src/main.ino
@@ -2,6 +2,7 @@
 #include <EEPROM.h>
 #include <WiFiManager.h>
 #include <ArduinoOTA.h>
+#include <Update.h>
 #include "WiFi.h"
 #include "ESPAsyncWebServer.h"
 #include "include/PersistSettings.h"
@@ -95,6 +96,7 @@ void setup()
     /**
     * Enable OTA update
     */
+    ArduinoOTA.setHostname(mdnsName);  // Use same name as mDNS
     ArduinoOTA
     .onStart([]() {
       String type;

--- a/Firmware/src/webserver.ino
+++ b/Firmware/src/webserver.ino
@@ -4,39 +4,6 @@ Description: This file contains all the functions we use for receiving and respo
 */
 
 #include "version.h"
-#include <Update.h>
-
-// Simple OTA update page
-const char* ota_html = R"rawliteral(
-<!DOCTYPE html>
-<html>
-<head>
-    <title>WInFiDEL Firmware Update</title>
-    <meta name="viewport" content="width=device-width, initial-scale=1">
-    <style>
-        body { font-family: Arial, sans-serif; margin: 40px; text-align: center; }
-        h1 { color: #333; }
-        form { margin: 20px auto; max-width: 400px; }
-        input[type=file] { margin: 20px 0; }
-        input[type=submit] { background: #007bff; color: white; padding: 10px 30px;
-                             border: none; cursor: pointer; font-size: 16px; }
-        input[type=submit]:hover { background: #0056b3; }
-        #progress { margin-top: 20px; display: none; }
-        .bar { height: 20px; background: #007bff; width: 0%; transition: width 0.3s; }
-        .bar-bg { background: #eee; border-radius: 4px; overflow: hidden; }
-    </style>
-</head>
-<body>
-    <h1>WInFiDEL Firmware Update</h1>
-    <form method="POST" action="/update" enctype="multipart/form-data" id="upload_form">
-        <input type="file" name="firmware" accept=".bin" required><br>
-        <input type="submit" value="Update Firmware">
-    </form>
-    <div id="progress"><div class="bar-bg"><div class="bar" id="bar"></div></div><span id="pct">0%</span></div>
-    <p><a href="/">Back to Home</a></p>
-</body>
-</html>
-)rawliteral";
 
 char sensor_data[SENSOR_STR_MAX_LEN] = {0};
 
@@ -242,43 +209,6 @@ void setupWebServer(void)
         }
     });
 
-    // Web-based OTA update page
-    server.on("/update", HTTP_GET, [](AsyncWebServerRequest *request) {
-        request->send(200, "text/html", ota_html);
-    });
-
-    // Handle firmware upload
-    server.on("/update", HTTP_POST,
-        [](AsyncWebServerRequest *request) {
-            bool success = !Update.hasError();
-            AsyncWebServerResponse *response = request->beginResponse(200, "text/plain",
-                success ? "Update successful! Rebooting..." : "Update failed!");
-            response->addHeader("Connection", "close");
-            request->send(response);
-            if (success) {
-                delay(1000);
-                ESP.restart();
-            }
-        },
-        [](AsyncWebServerRequest *request, String filename, size_t index, uint8_t *data, size_t len, bool final) {
-            if (!index) {
-                Serial.printf("Update Start: %s\n", filename.c_str());
-                if (!Update.begin(UPDATE_SIZE_UNKNOWN)) {
-                    Update.printError(Serial);
-                }
-            }
-            if (Update.write(data, len) != len) {
-                Update.printError(Serial);
-            }
-            if (final) {
-                if (Update.end(true)) {
-                    Serial.printf("Update Success: %u bytes\n", index + len);
-                } else {
-                    Update.printError(Serial);
-                }
-            }
-        }
-    );
 
 }
 

--- a/Firmware/src/webserver.ino
+++ b/Firmware/src/webserver.ino
@@ -4,6 +4,39 @@ Description: This file contains all the functions we use for receiving and respo
 */
 
 #include "version.h"
+#include <Update.h>
+
+// Simple OTA update page
+const char* ota_html = R"rawliteral(
+<!DOCTYPE html>
+<html>
+<head>
+    <title>WInFiDEL Firmware Update</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <style>
+        body { font-family: Arial, sans-serif; margin: 40px; text-align: center; }
+        h1 { color: #333; }
+        form { margin: 20px auto; max-width: 400px; }
+        input[type=file] { margin: 20px 0; }
+        input[type=submit] { background: #007bff; color: white; padding: 10px 30px;
+                             border: none; cursor: pointer; font-size: 16px; }
+        input[type=submit]:hover { background: #0056b3; }
+        #progress { margin-top: 20px; display: none; }
+        .bar { height: 20px; background: #007bff; width: 0%; transition: width 0.3s; }
+        .bar-bg { background: #eee; border-radius: 4px; overflow: hidden; }
+    </style>
+</head>
+<body>
+    <h1>WInFiDEL Firmware Update</h1>
+    <form method="POST" action="/update" enctype="multipart/form-data" id="upload_form">
+        <input type="file" name="firmware" accept=".bin" required><br>
+        <input type="submit" value="Update Firmware">
+    </form>
+    <div id="progress"><div class="bar-bg"><div class="bar" id="bar"></div></div><span id="pct">0%</span></div>
+    <p><a href="/">Back to Home</a></p>
+</body>
+</html>
+)rawliteral";
 
 char sensor_data[SENSOR_STR_MAX_LEN] = {0};
 
@@ -209,6 +242,43 @@ void setupWebServer(void)
         }
     });
 
+    // Web-based OTA update page
+    server.on("/update", HTTP_GET, [](AsyncWebServerRequest *request) {
+        request->send(200, "text/html", ota_html);
+    });
+
+    // Handle firmware upload
+    server.on("/update", HTTP_POST,
+        [](AsyncWebServerRequest *request) {
+            bool success = !Update.hasError();
+            AsyncWebServerResponse *response = request->beginResponse(200, "text/plain",
+                success ? "Update successful! Rebooting..." : "Update failed!");
+            response->addHeader("Connection", "close");
+            request->send(response);
+            if (success) {
+                delay(1000);
+                ESP.restart();
+            }
+        },
+        [](AsyncWebServerRequest *request, String filename, size_t index, uint8_t *data, size_t len, bool final) {
+            if (!index) {
+                Serial.printf("Update Start: %s\n", filename.c_str());
+                if (!Update.begin(UPDATE_SIZE_UNKNOWN)) {
+                    Update.printError(Serial);
+                }
+            }
+            if (Update.write(data, len) != len) {
+                Update.printError(Serial);
+            }
+            if (final) {
+                if (Update.end(true)) {
+                    Serial.printf("Update Success: %u bytes\n", index + len);
+                } else {
+                    Update.printError(Serial);
+                }
+            }
+        }
+    );
 
 }
 


### PR DESCRIPTION
# Fix mDNS hostname and enable ArduinoOTA

## Summary
- **Fixed mDNS hostname issue** - `winfidel.local` was not resolving because `ArduinoOTA.begin()` was overriding the mDNS hostname. Added `ArduinoOTA.setHostname(mdnsName)` before `ArduinoOTA.begin()` to ensure consistent hostname.
- **Fixed ArduinoOTA** - Changed partition table from `huge_app.csv` to `min_spiffs.csv` to enable OTA updates. ArduinoOTA requires two app partitions (ota_0 and ota_1) to write firmware to the inactive partition before switching.
- **Updated README** - Removed outdated `uploadfs` instructions (web assets are now embedded in firmware) and added OTA update documentation.

## Changes
- `platformio.ini` - Changed partition table to `min_spiffs.csv` (enables dual OTA partitions)
- `src/main.ino` - Added `ArduinoOTA.setHostname(mdnsName)` to fix mDNS
- `README.md` - Updated build instructions and added OTA section

## Technical notes
- `huge_app.csv`: single 3MB app partition (no OTA support)
- `min_spiffs.csv`: two 1.875MB app partitions (OTA supported)
- Current firmware size: ~1.63MB (fits with 13% headroom)
- SPIFFS reduced from 896KB to 128KB (not used since web assets are embedded)

## Test plan
- [x] Verify `winfidel.local` resolves correctly after boot
- [x] Test ArduinoOTA: `pio run --target upload --environment esp32_ota`
- [x] Confirm device reboots with new firmware after OTA update
- [x] Verify USB upload still works with new partition table